### PR TITLE
fix: remove number in reverse

### DIFF
--- a/vibe-check-frontend/src/GetTokens.vue
+++ b/vibe-check-frontend/src/GetTokens.vue
@@ -107,8 +107,14 @@ const activateCamera = async () => {
             const displaySize = { width: videoFeed.value!.clientWidth, height: videoFeed.value!.clientHeight }
             faceApi.matchDimensions(canvasOutput.value!, displaySize)
             lastDetections.value = await faceApi.detectAllFaces(videoFeed.value!, new faceApi.TinyFaceDetectorOptions())
-            const resizedDetections = faceApi.resizeResults(lastDetections.value, displaySize)
-            faceApi.draw.drawDetections(canvasOutput.value!, resizedDetections);
+            var resizedDetections = faceApi.resizeResults(lastDetections.value, displaySize)
+            const box = {
+                x: resizedDetections[0].box.left,
+                y: resizedDetections[0].box.top,
+                width: resizedDetections[0].box.width,
+                height: resizedDetections[0].box.height,
+            };
+            faceApi.draw.drawDetections(canvasOutput.value!, box);
         }, 1000);
     } catch (e) {
         console.error(e);

--- a/vibe-check-frontend/src/GetTokens.vue
+++ b/vibe-check-frontend/src/GetTokens.vue
@@ -107,14 +107,25 @@ const activateCamera = async () => {
             const displaySize = { width: videoFeed.value!.clientWidth, height: videoFeed.value!.clientHeight }
             faceApi.matchDimensions(canvasOutput.value!, displaySize)
             lastDetections.value = await faceApi.detectAllFaces(videoFeed.value!, new faceApi.TinyFaceDetectorOptions())
-            var resizedDetections = faceApi.resizeResults(lastDetections.value, displaySize)
-            const box = {
-                x: resizedDetections[0].box.left,
-                y: resizedDetections[0].box.top,
-                width: resizedDetections[0].box.width,
-                height: resizedDetections[0].box.height,
-            };
-            faceApi.draw.drawDetections(canvasOutput.value!, box);
+            if (lastDetections.value.length > 0) {
+                var score =  lastDetections.value[0].score.toFixed(2);
+                var resizedDetections = faceApi.resizeResults(lastDetections.value, displaySize)
+
+                var canvas = canvasOutput.value!;
+                var context = canvas.getContext("2d")!;
+
+                const box = {
+                    x: resizedDetections[0].box.left,
+                    y: resizedDetections[0].box.top,
+                    width: resizedDetections[0].box.width,
+                    height: resizedDetections[0].box.height,
+                };
+                faceApi.draw.drawDetections(canvas, box);
+                context.scale(-1, 1);
+                context.fillStyle = "blue";
+                context.font = "bold 16px Arial";
+                context.fillText(score, - canvas.width * 0.1, canvas.height * 0.1);
+            }
         }, 1000);
     } catch (e) {
         console.error(e);

--- a/vibe-check-frontend/src/GetTokens.vue
+++ b/vibe-check-frontend/src/GetTokens.vue
@@ -107,6 +107,7 @@ const activateCamera = async () => {
             const displaySize = { width: videoFeed.value!.clientWidth, height: videoFeed.value!.clientHeight }
             faceApi.matchDimensions(canvasOutput.value!, displaySize)
             lastDetections.value = await faceApi.detectAllFaces(videoFeed.value!, new faceApi.TinyFaceDetectorOptions())
+            // We shall only process detection if at least one face has been detected
             if (lastDetections.value.length > 0) {
                 var score =  lastDetections.value[0].score.toFixed(2);
                 var resizedDetections = faceApi.resizeResults(lastDetections.value, displaySize)


### PR DESCRIPTION
Linked to https://github.com/Hyle-org/vibe-check/issues/14
Face recognition estimation was reversed. This is due to the fact that the picture is processed in reversed.
To make an easy solution, I extracted the score and show it in a fixed place on the canvas
![image](https://github.com/user-attachments/assets/f1ddd371-0664-4da4-b4ef-3c95bc7e5464)
